### PR TITLE
Fix up tests

### DIFF
--- a/__tests__/all-encodings.test.ts
+++ b/__tests__/all-encodings.test.ts
@@ -36,7 +36,7 @@ describe("All Encodings", () => {
         test(`should encode and decode "${testString.substring(0, 20)}${
           testString.length > 20 ? "..." : ""
         }" correctly`, () => {
-          const textBytes = Buffer.from(testString);
+          const textBytes = testString;
           const tokens = encoding.encode(textBytes);
           expect(
             ArrayBuffer.isView(tokens) && tokens.BYTES_PER_ELEMENT === 4

--- a/__tests__/benchmark.mts
+++ b/__tests__/benchmark.mts
@@ -2,9 +2,9 @@ import { getEncoding, encodingForModel } from "../index.js";
 import * as mitata from "mitata";
 
 // Sample texts of different sizes
-const smallText = Buffer.from("Hello, world!");
-const mediumText = Buffer.from("A".repeat(1000));
-const largeText = Buffer.from("B".repeat(10000));
+const smallText = ("Hello, world!");
+const mediumText = ("A".repeat(1000));
+const largeText = ("B".repeat(10000));
 
 // Get different encodings
 const cl100k = getEncoding("cl100k_base");

--- a/__tests__/encoding.test.ts
+++ b/__tests__/encoding.test.ts
@@ -33,8 +33,7 @@ describe("tiktoken-rs-node", () => {
     test("should encode and decode text correctly", () => {
       const encoding = getEncoding("cl100k_base");
       const text = "Hello, world!";
-      const textBytes = Buffer.from(text);
-      const tokens = encoding.encode(textBytes);
+      const tokens = encoding.encode(text);
 
       expect(ArrayBuffer.isView(tokens) && tokens.BYTES_PER_ELEMENT === 4).toBe(
         true
@@ -47,8 +46,7 @@ describe("tiktoken-rs-node", () => {
 
     test("should handle empty input", () => {
       const encoding = getEncoding("cl100k_base");
-      const emptyBytes = Buffer.from("");
-      const tokens = encoding.encode(emptyBytes);
+      const tokens = encoding.encode("");
       expect(ArrayBuffer.isView(tokens) && tokens.BYTES_PER_ELEMENT === 4).toBe(
         true
       );
@@ -61,22 +59,15 @@ describe("tiktoken-rs-node", () => {
     test("should handle special characters", () => {
       const encoding = getEncoding("cl100k_base");
       const text = "🚀 Special characters: äöü 你好 😊";
-      const textBytes = Buffer.from(text);
-      const tokens = encoding.encode(textBytes);
+      const tokens = encoding.encode(text);
 
       const decoded = encoding.decode(tokens);
       expect(decoded).toBe(text);
     });
 
-    test("should throw error for invalid UTF-8 input", () => {
+    test("should not throw error for invalid UTF-8 input", () => {
       const encoding = getEncoding("cl100k_base");
-      // Create a buffer with an incomplete UTF-8 sequence (first byte of a 2-byte sequence)
-      const invalidBytes = Buffer.from([0xc2]); // First byte of UTF-8 2-byte sequence
-
-      // The encoding should throw an error for invalid UTF-8
-      expect(() => encoding.encode(invalidBytes)).toThrow(
-        "Error while encoding text to UTF-8"
-      );
+      expect(() => encoding.encode("\0")).not.toThrow();
     });
   });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,6 @@
 export declare function getEncoding(encoding: 'gpt2' | 'r50k_base' | 'p50k_base' | 'p50k_edit' | 'cl100k_base' | 'o200k_base'): Encoding
 export declare function encodingForModel(modelName: string): Encoding
 export declare class Encoding {
-  encode(text: Uint8Array): Uint32Array
+  encode(text: string): Uint32Array
   decode(tokens: Uint32Array): string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ESNext"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes tests after #1 

One key change: now encode mostly won't throw errors when utf8 is invalid, since we're using node's builtin encoding functions. instead it passes through replacement characters


Also now I can do a benchmark changes from #1 are about 8% faster:

with changes from #1 and #2:

```
cl100k_base - decode small tokens  231.23 ns/iter 233.40 ns    █▄                
                          (207.83 ns … 390.78 ns) 285.37 ns    ███▆              
                          ( 15.83  b …  48.24  b)  32.05  b ▁▁▂████▅▅▄▃▂▂▇▂▁▁▁▁▁▁

cl100k_base - decode medium tokens 685.17 ns/iter 702.45 ns    █ ▆  ▄            
                            (615.11 ns … 1.05 µs) 835.84 ns    ███▅▅█            
                          (  0.99 kb …   0.99 kb)   0.99 kb ▂▅▄██████▇█▅▃▂▂▂▁▁▁▁▂

cl100k_base - decode large tokens    7.63 µs/iter   7.63 µs ██                   
                              (7.50 µs … 8.05 µs)   8.00 µs ██▅▅                 
                          (  2.20 kb …   2.20 kb)   2.20 kb ████▇▇▁▇▁▁▁▇▁▁▁▁▁▁▇▁▇
```


prev on 195690e60f65eb96b7e83a77f141e8e1abdd93fc:

```
cl100k_base - decode small tokens  250.57 ns/iter 263.03 ns   ▃█▅                
                          (212.65 ns … 677.96 ns) 363.18 ns  ████▇▃█             
                          ( 16.51  b …  48.24  b)  32.05  b ▂████████▃▂▃▃▂▂▁▂▂▁▁▁

cl100k_base - decode medium tokens 711.87 ns/iter 742.64 ns    █ ▇ ▄ ▄           
                            (622.61 ns … 1.20 µs) 834.69 ns   ▃█▇█▇█████▃█▄      
                          (  0.99 kb …   1.04 kb)   1.00 kb ▅██████████████▅▅▅▃▄▂

cl100k_base - decode large tokens    7.88 µs/iter   8.03 µs █  █ █   █          █
                              (7.52 µs … 8.62 µs)   8.26 µs █▅ █▅█ ▅ █  ▅ ▅▅   ▅█
                          ( 85.08  b …   2.20 kb)   1.99 kb ██▁███▁█▁█▁▁█▁██▁▁▁██
```




